### PR TITLE
Fix README id reference in inputs path example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
         id: package-node-version
 
       - name: Show version number
-        run: echo "Version is ${{ steps.package-version.outputs.version }}"
+        run: echo "Version is ${{ steps.package-node-version.outputs.version }}"
         # Version is 12.13.x
 ```
 


### PR DESCRIPTION
### Summary of changes

- fixed the id reference in the `README.md` from `steps.package-version` -> steps.package-node-version